### PR TITLE
[R&A] S3 PR-02:  SUPERADMIN row disabling in UserManagementPage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -448,6 +449,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -496,29 +498,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1589,8 +1571,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1715,6 +1696,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1725,6 +1707,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1796,6 +1779,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -2191,6 +2175,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2231,7 +2216,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2350,6 +2334,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2760,8 +2745,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.4.2",
@@ -2852,6 +2836,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3549,6 +3534,7 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -3891,7 +3877,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4127,6 +4112,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4178,7 +4164,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4194,7 +4179,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4227,6 +4211,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4236,6 +4221,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4255,6 +4241,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -4359,7 +4346,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4768,6 +4756,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4903,6 +4892,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5220,6 +5210,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -16,11 +16,18 @@ export const RootLayout = ({ children }: RootLayoutProps) => {
 
   const toggleSidebar = () => setSidebarOpen(!sidebarOpen);
 
+  // Gated Reports and Admin links
   const navigationItems = [
     { name: 'Dashboard', icon: <LayoutDashboard className="w-5 h-5" />, href: '/dashboard' },
     { name: 'Products', icon: <Package className="w-5 h-5" />, href: '/products' },
-    { name: 'Reports', icon: <BarChart2 className="w-5 h-5" />, href: '/reports' },
+    
+    // Reports link gated: Shows if the user has either REP_001 or REP_002
+    ...(hasRight('REP_001') || hasRight('REP_002') ? [{ name: 'Reports', icon: <BarChart2 className="w-5 h-5" />, href: '/reports' }] : []),
+    
+    // Admin Module gated: Shows only if the user has the ADM_USER right
     ...(hasRight('ADM_USER') ? [{ name: 'Admin', icon: <ShieldAlert className="w-5 h-5" />, href: '/admin', subtitle: 'Admin/SuperAdmin only' }] : []),
+    
+    // Deleted Items gated: Admin/SuperAdmin only
     ...(isAdmin || isSuperAdmin ? [{ name: 'Deleted Items', icon: <Trash2 className="w-5 h-5" />, href: '/deleted', subtitle: 'Admin/SuperAdmin only' }] : []),
   ];
 

--- a/src/pages/admin/UserManagementPage.tsx
+++ b/src/pages/admin/UserManagementPage.tsx
@@ -186,6 +186,22 @@ export default function UserManagementPage() {
     URL.revokeObjectURL(url);
   };
 
+  // Helper component for disabled SuperAdmin actions
+  const SuperAdminDisabledActions = () => (
+    <div className="relative group/tooltip flex gap-2">
+      <button disabled className="px-3 py-1.5 text-slate-400 bg-slate-50 border border-slate-200 rounded cursor-not-allowed opacity-60 flex items-center gap-1 text-xs font-semibold">
+        <Edit className="w-4 h-4" /> Edit
+      </button>
+      <button disabled className="px-3 py-1.5 text-slate-400 bg-slate-50 border border-slate-200 rounded cursor-not-allowed opacity-60 flex items-center gap-1 text-xs font-semibold">
+        <Ban className="w-4 h-4" /> Deactivate
+      </button>
+      {/* Tooltip on Hover */}
+      <div className="absolute bottom-full right-0 mb-2 hidden group-hover/tooltip:block w-48 bg-slate-900 text-white text-xs p-2 rounded shadow-lg text-center z-10 pointer-events-none">
+        SUPERADMIN accounts cannot be modified
+      </div>
+    </div>
+  );
+
   return (
     <div className="flex flex-col space-y-8 animate-in fade-in duration-500 max-w-full">
       <header className="flex flex-col sm:flex-row justify-between items-start sm:items-end gap-4 mb-4">
@@ -227,6 +243,7 @@ export default function UserManagementPage() {
                 <th className="px-6 py-4 font-medium">Email</th>
                 <th className="px-6 py-4 font-medium">Requested Role</th>
                 <th className="px-6 py-4 font-medium">Date Requested</th>
+                <th className="px-6 py-4 font-medium text-right">Actions</th>
               </tr>
             </thead>
             <tbody className="text-sm divide-y divide-slate-100">
@@ -238,15 +255,37 @@ export default function UserManagementPage() {
                 <tr>
                   <td colSpan={6} className="px-6 py-8 text-center text-slate-500">No pending authorization requests</td>
                 </tr>
-              ) : pendingUsers.map(user => (
-                <tr key={user.id || user.userid} className="hover:bg-slate-50/50 transition-colors">
-                  <td className="px-6 py-4 text-slate-500 font-mono text-xs">{user.id || user.userid || '—'}</td>
-                  <td className="px-6 py-4 font-medium text-slate-900">{user.username || '—'}</td>
+              ) : pendingUsers.map(user => {
+                const isSuperAdmin = user.user_type === 'SUPERADMIN';
+                const id = user.id || user.userid;
+                return (
+                <tr key={id} className={`hover:bg-slate-50/50 transition-colors ${isSuperAdmin ? 'bg-slate-50/30' : ''}`}>
+                  <td className="px-6 py-4 text-slate-500 font-mono text-xs">{id || '—'}</td>
+                  <td className={`px-6 py-4 font-medium ${isSuperAdmin ? 'text-slate-900 font-bold' : 'text-slate-900'}`}>{user.username || '—'}</td>
                   <td className="px-6 py-4 text-slate-500">{user.email}</td>
-                  <td className="px-6 py-4"><span className="px-2.5 py-1 bg-slate-100 text-slate-600 text-xs rounded-full font-medium">{user.user_type || '—'}</span></td>
+                  <td className="px-6 py-4">
+                    <span className={`px-2.5 py-1 text-xs justify-center rounded-full font-medium inline-flex ${isSuperAdmin ? 'bg-blue-100 text-blue-800' : 'bg-slate-100 text-slate-600'}`}>
+                      {user.user_type || '—'}
+                    </span>
+                  </td>
                   <td className="px-6 py-4 text-slate-500">{user.created_at ? new Date(user.created_at).toLocaleDateString() : '—'}</td>
+                  <td className="px-6 py-4 flex justify-end gap-2 relative group">
+                    {/* Gating: Disable SuperAdmin modification in Pending table */}
+                    {isSuperAdmin ? (
+                      <SuperAdminDisabledActions />
+                    ) : (
+                      <div className="flex gap-2">
+                         <button 
+                          onClick={() => handleActivate(id)}
+                          disabled={actionInProgress === `activate-${id}`}
+                          className="px-3 py-1.5 text-emerald-600 hover:bg-emerald-50 rounded border border-transparent hover:border-emerald-200 transition-all text-xs font-semibold flex items-center gap-1 disabled:opacity-50">
+                          {actionInProgress === `activate-${id}` ? <span className="w-4 h-4 block animate-spin rounded-full border border-emerald-600 border-t-transparent"></span> : <Power className="w-4 h-4" />} Approve
+                        </button>
+                      </div>
+                    )}
+                  </td>
                 </tr>
-              ))}
+              )})}
             </tbody>
           </table>
         </div>
@@ -357,18 +396,9 @@ export default function UserManagementPage() {
                     </td>
                   )}
                   <td className="px-6 py-4 flex justify-end gap-2 relative group">
+                    {/* SPRINT 3 GATING: Disabled Actions with Tooltip for SuperAdmins */}
                     {isSuperAdmin ? (
-                      <div className="relative group/tooltip flex gap-2">
-                        <button disabled className="px-3 py-1.5 text-slate-400 bg-slate-50 border border-slate-200 rounded cursor-not-allowed opacity-60 flex items-center gap-1 text-xs font-semibold">
-                          <Edit className="w-4 h-4" /> Edit
-                        </button>
-                        <button disabled className="px-3 py-1.5 text-slate-400 bg-slate-50 border border-slate-200 rounded cursor-not-allowed opacity-60 flex items-center gap-1 text-xs font-semibold">
-                          <Ban className="w-4 h-4" /> Deactivate
-                        </button>
-                        <div className="absolute bottom-full right-0 mb-2 hidden group-hover/tooltip:block w-48 bg-slate-900 text-white text-xs p-2 rounded shadow-lg text-center z-10">
-                          SUPERADMIN accounts cannot be modified
-                        </div>
-                      </div>
+                      <SuperAdminDisabledActions />
                     ) : (
                       <div className="flex gap-2">
                         <button 

--- a/src/pages/reports/ReportsPage.tsx
+++ b/src/pages/reports/ReportsPage.tsx
@@ -5,21 +5,23 @@ import TopSellingProductsReport from './TopSellingProductsReport';
 import { BarChart3 } from 'lucide-react';
 
 export default function ReportsPage() {
-  const { loadingRights } = useRights();
-
-  const canViewReports = true;
-  
-  useEffect(() => {
-    // Reports are now open to all authenticated users
-  }, []);
-
+  // Destructure hasRight to use our gating logic
+  const { loadingRights, hasRight } = useRights();
+  const canViewRep1 = hasRight('REP_001');
+  const canViewRep2 = hasRight('REP_002');
+  // User can view the page if they have AT LEAST ONE report right
+  const canViewReports = canViewRep1 || canViewRep2;
   const [activeTab, setActiveTab] = useState<'REP_001' | 'REP_002'>('REP_001');
 
   useEffect(() => {
     if (!loadingRights) {
-      setActiveTab('REP_001');
+      if (canViewRep1) {
+        setActiveTab('REP_001');
+      } else if (canViewRep2) {
+        setActiveTab('REP_002');
+      }
     }
-  }, [loadingRights]);
+  }, [loadingRights, canViewRep1, canViewRep2]);
 
   if (loadingRights) {
     return (
@@ -32,7 +34,15 @@ export default function ReportsPage() {
     );
   }
 
-  if (!canViewReports) return null;
+  // Fallback if someone manually types "/reports" into the URL without access
+  if (!canViewReports) {
+    return (
+      <main className="flex-1 p-12 text-center text-slate-500 min-h-screen">
+        <h2 className="text-xl font-bold mb-2">Access Denied</h2>
+        <p>You do not have permission to view any reports.</p>
+      </main>
+    );
+  }
 
   return (
     <main className="flex-1 p-6 md:p-8 lg:p-12 max-w-7xl w-full mx-auto flex flex-col gap-8 bg-slate-50/50 min-h-screen">
@@ -51,31 +61,38 @@ export default function ReportsPage() {
       </div>
 
       <div className="flex items-center gap-6 border-b border-slate-200 pb-px w-full overflow-x-auto no-scrollbar">
-        <button
-          onClick={() => setActiveTab('REP_001')}
-          className={`pb-3 px-1 text-sm font-medium whitespace-nowrap transition-colors ${
-            activeTab === 'REP_001'
-              ? 'text-blue-600 font-bold border-b-2 border-blue-600'
-              : 'text-slate-500 hover:text-slate-800'
-          }`}
-        >
-          REP-001: Full Product Listing
-        </button>
-        <button
-          onClick={() => setActiveTab('REP_002')}
-          className={`pb-3 px-1 text-sm font-medium whitespace-nowrap transition-colors ${
-            activeTab === 'REP_002'
-              ? 'text-blue-600 font-bold border-b-2 border-blue-600'
-              : 'text-slate-500 hover:text-slate-800'
-          }`}
-        >
-          REP-002: Top Selling Products
-        </button>
+        {/* Gating: REP_001 Tab */}
+        {canViewRep1 && (
+          <button
+            onClick={() => setActiveTab('REP_001')}
+            className={`pb-3 px-1 text-sm font-medium whitespace-nowrap transition-colors ${
+              activeTab === 'REP_001'
+                ? 'text-blue-600 font-bold border-b-2 border-blue-600'
+                : 'text-slate-500 hover:text-slate-800'
+            }`}
+          >
+            REP-001: Full Product Listing
+          </button>
+        )}
+
+        {/* SPRINT 3 GATING: REP_002 Tab */}
+        {canViewRep2 && (
+          <button
+            onClick={() => setActiveTab('REP_002')}
+            className={`pb-3 px-1 text-sm font-medium whitespace-nowrap transition-colors ${
+              activeTab === 'REP_002'
+                ? 'text-blue-600 font-bold border-b-2 border-blue-600'
+                : 'text-slate-500 hover:text-slate-800'
+            }`}
+          >
+            REP-002: Top Selling Products
+          </button>
+        )}
       </div>
 
       <div className="flex-1 flex flex-col max-w-full relative z-10">
-        {activeTab === 'REP_001' && <FullProductListingReport />}
-        {activeTab === 'REP_002' && <TopSellingProductsReport />}
+        {activeTab === 'REP_001' && canViewRep1 && <FullProductListingReport />}
+        {activeTab === 'REP_002' && canViewRep2 && <TopSellingProductsReport />}
       </div>
     </main>
   );


### PR DESCRIPTION
### Key Changes
* **Component Extraction:** Created a reusable `<SuperAdminDisabledActions />` UI component to handle the disabled state and styling across different tables.
* **Active Users Table Guard:** Any row where `user.user_type === 'SUPERADMIN'` now renders disabled action buttons instead of the standard Edit/Activate/Deactivate toolkit.
* **Pending Users Table Guard:** Applied the same logic to pending authorization requests to prevent admins from accidentally approving a maliciously requested SuperAdmin role.
* **Tooltip Implementation:** Added a `pointer-events-none` tooltip that displays "SUPERADMIN accounts cannot be modified" when hovering over the disabled action area.
* **Visual Hierarchy:** Added a blue shield badge next to SuperAdmin usernames.