### PR TITLE
[DB] Enable and enforce RLS on core tables

### DIFF
--- a/rls-enforcement.sql
+++ b/rls-enforcement.sql
@@ -1,0 +1,14 @@
+-- Enable RLS
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.usermodule_rights ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.product ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.pricehist ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_module ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.module ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rights ENABLE ROW LEVEL SECURITY;
+
+-- Optional but recommended: force RLS so even table owners must follow policies
+ALTER TABLE public.users FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.usermodule_rights FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.product FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.pricehist FORCE ROW LEVEL SECURITY;


### PR DESCRIPTION
- Addressed Supabase Security Advisor warnings:
     - Enabled Row Level Security (RLS) on all public tables relevant to HopePMS.
     - Applied FORCE RLS on sensitive tables so even table owners must follow policies.