### PR TITLE
[FIX] Incomplete Stamp History

### DIFF
--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -1,5 +1,6 @@
 import { supabase } from '../lib/supabase';
 import { createStamp } from '../utils/stamp';
+import { addStampEntry } from './stampHistory';
 
 export type UserType = 'USER' | 'ADMIN' | 'SUPERADMIN';
 
@@ -57,7 +58,9 @@ export const addProduct = async (product: Partial<Product>) => {
     console.error('Error adding product:', error);
     throw error;
   }
-  return data?.[0] as Product;
+  const saved = data?.[0] as Product;
+  await addStampEntry(saved.prodcode, stamp);
+  return saved;
 };
 
 /**
@@ -75,7 +78,9 @@ export const updateProduct = async (prodcode: string, product: Partial<Product>)
     console.error('Error updating product:', error);
     throw error;
   }
-  return data?.[0] as Product;
+  const updated = data?.[0] as Product;
+  await addStampEntry(prodcode, stamp);
+  return updated;
 };
 
 /**
@@ -96,6 +101,7 @@ export const softDeleteProduct = async (prodcode: string) => {
   if (!data || data.length === 0) {
     throw new Error('Product not found or you do not have permission to delete it.');
   }
+  await addStampEntry(prodcode, stamp);
   return data[0] as Product;
 };
 
@@ -117,6 +123,7 @@ export const recoverProduct = async (prodcode: string) => {
   if (!data || data.length === 0) {
     throw new Error('Product not found or you do not have permission to recover it.');
   }
+  await addStampEntry(prodcode, stamp);
   return data[0] as Product;
 };
 

--- a/src/api/stampHistory.ts
+++ b/src/api/stampHistory.ts
@@ -1,0 +1,41 @@
+import { supabase } from '../lib/supabase';
+
+export interface StampEntry {
+  id: number;
+  prodcode: string;
+  stamp: string;
+  created_at: string;
+}
+
+/**
+ * Inserts a new stamp history entry for a product.
+ * Called after every product mutation alongside the stamp written to product.stamp.
+ */
+export const addStampEntry = async (prodcode: string, stamp: string): Promise<void> => {
+  const { error } = await supabase
+    .from('product_stamp_hist')
+    .insert([{ prodcode, stamp }]);
+
+  if (error) {
+    // Log but don't throw — stamp history failure should not block the main operation
+    console.error('Error writing stamp history entry:', error);
+  }
+};
+
+/**
+ * Fetches all stamp history entries for a product, newest first.
+ */
+export const getStampHistory = async (prodcode: string): Promise<StampEntry[]> => {
+  const { data, error } = await supabase
+    .from('product_stamp_hist')
+    .select('id, prodcode, stamp, created_at')
+    .eq('prodcode', prodcode)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('Error fetching stamp history:', error);
+    throw error;
+  }
+
+  return (data ?? []) as StampEntry[];
+};

--- a/src/components/products/EditProductModal.tsx
+++ b/src/components/products/EditProductModal.tsx
@@ -1,22 +1,26 @@
 import React, { useState, useEffect } from 'react';
 import { updateProduct, type Product } from '../../api/products';
+import { addPriceEntry } from '../../api/priceHistory';
 
 export interface EditProductModalProps {
   isOpen: boolean;
   onClose: () => void;
   product: Product;
-  onProductSaved?: (product: Product) => void;
+  currentPrice?: number;
+  onProductSaved?: (product: Product, newPrice?: number) => void;
 }
 
 export const EditProductModal: React.FC<EditProductModalProps> = ({
   isOpen,
   onClose,
   product,
+  currentPrice,
   onProductSaved,
 }) => {
   const [formData, setFormData] = useState({
     description: '',
     unit: 'pc',
+    price: '',
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -30,10 +34,11 @@ export const EditProductModal: React.FC<EditProductModalProps> = ({
       setFormData({
         description: product.description || '',
         unit: product.unit || 'pc',
+        price: currentPrice !== undefined ? String(currentPrice) : '',
       });
       setErrors({});
     }
-  }, [isOpen, product]);
+  }, [isOpen, product, currentPrice]);
 
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -44,6 +49,13 @@ export const EditProductModal: React.FC<EditProductModalProps> = ({
 
     if (!formData.unit) {
       newErrors.unit = 'Unit is required';
+    }
+
+    const priceValue = parseFloat(formData.price);
+    if (formData.price.trim() === '') {
+      newErrors.price = 'Price is required';
+    } else if (isNaN(priceValue) || priceValue <= 0) {
+      newErrors.price = 'Price must be a positive number';
     }
 
     setErrors(newErrors);
@@ -82,16 +94,30 @@ export const EditProductModal: React.FC<EditProductModalProps> = ({
 
     setIsLoading(true);
     try {
+      // 1. Update core product fields
       const updatedProduct = await updateProduct(product.prodcode, {
         description: formData.description || null,
         unit: formData.unit || null,
       });
 
+      // 2. If price changed, insert a new pricehist entry with today's date
+      const newPrice = parseFloat(formData.price);
+      const priceChanged = newPrice !== currentPrice;
+
+      if (priceChanged) {
+        const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+        await addPriceEntry({
+          prodcode: product.prodcode,
+          effdate: today,
+          unitprice: newPrice,
+        });
+      }
+
       setErrors({});
 
-      // Notify parent component
+      // Notify parent component with updated product and new price (if changed)
       if (onProductSaved) {
-        onProductSaved(updatedProduct);
+        onProductSaved(updatedProduct, priceChanged ? newPrice : undefined);
       }
 
       onClose();
@@ -269,6 +295,49 @@ export const EditProductModal: React.FC<EditProductModalProps> = ({
                   {errors.unit}
                 </p>
               )}
+            </div>
+
+            {/* Price Field */}
+            <div>
+              <label
+                className="block text-sm font-medium text-on-surface mb-1.5"
+                htmlFor="price"
+              >
+                Price
+              </label>
+              <div className="relative">
+                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-on-surface-variant text-sm font-medium">
+                  $
+                </span>
+                <input
+                  id="price"
+                  name="price"
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  value={formData.price}
+                  onChange={handleInputChange}
+                  aria-invalid={!!errors.price}
+                  aria-describedby={errors.price ? 'price-error' : undefined}
+                  className={`block w-full rounded-lg bg-surface-container-highest text-on-surface shadow-sm focus:ring focus:ring-opacity-20 sm:text-sm outline-none transition-all pl-8 pr-4 py-2.5 ${
+                    errors.price
+                      ? 'border-error focus:border-error focus:ring-error'
+                      : 'border-outline-variant/10 focus:border-primary focus:ring-primary'
+                  }`}
+                  placeholder="0.00"
+                />
+              </div>
+              {errors.price && (
+                <p
+                  id="price-error"
+                  className="mt-2 text-xs text-error font-medium"
+                >
+                  {errors.price}
+                </p>
+              )}
+              <p className="mt-1.5 text-xs text-on-surface-variant">
+                Changing the price will create a new entry in the price history dated today.
+              </p>
             </div>
 
             {/* Submit error message */}

--- a/src/components/products/PriceHistoryPanel.tsx
+++ b/src/components/products/PriceHistoryPanel.tsx
@@ -25,6 +25,15 @@ export const PriceHistoryPanel: React.FC<PriceHistoryPanelProps> = ({
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
 
+  // Reset cached data whenever the panel is closed so the next open always
+  // triggers a fresh fetch from the API.
+  useEffect(() => {
+    if (!isOpen) {
+      setHistory(null);
+      setFetchError(null);
+    }
+  }, [isOpen]);
+
   useEffect(() => {
     if (!isOpen || history !== null) {
       return;

--- a/src/components/products/StampHistoryPanel.tsx
+++ b/src/components/products/StampHistoryPanel.tsx
@@ -1,0 +1,182 @@
+import React, { useEffect, useState } from 'react';
+import { getStampHistory, type StampEntry } from '../../api/stampHistory';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+const PAGE_SIZE = 10;
+
+interface StampHistoryPanelProps {
+  productId: string;
+  isOpen: boolean;
+  colSpan: number;
+}
+
+export const StampHistoryPanel: React.FC<StampHistoryPanelProps> = ({
+  productId,
+  isOpen,
+  colSpan,
+}) => {
+  const [history, setHistory] = useState<StampEntry[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // Reset cached data whenever the panel is closed
+  useEffect(() => {
+    if (!isOpen) {
+      setHistory(null);
+      setFetchError(null);
+      setCurrentPage(1);
+    }
+  }, [isOpen]);
+
+  // Fetch on open (only when history is null)
+  useEffect(() => {
+    if (!isOpen || history !== null) {
+      return;
+    }
+
+    const fetchHistory = async () => {
+      try {
+        setIsLoading(true);
+        setFetchError(null);
+        const data = await getStampHistory(productId);
+        setHistory(data);
+      } catch (error) {
+        console.error('Stamp history load error:', error);
+        setFetchError('Unable to load stamp history. Please try again.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchHistory();
+  }, [isOpen, history, productId]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const totalPages = history ? Math.max(1, Math.ceil(history.length / PAGE_SIZE)) : 1;
+  const startIndex = (currentPage - 1) * PAGE_SIZE;
+  const pageItems = history ? history.slice(startIndex, startIndex + PAGE_SIZE) : [];
+
+  return (
+    <tr className="bg-surface-container-lowest">
+      <td colSpan={colSpan} className="px-6 pb-4 pt-0">
+        <div className="rounded-[2rem] border border-surface-container-highest bg-white shadow-sm p-6">
+          {/* Header */}
+          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between mb-6">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500 mb-2">
+                Stamp History
+              </p>
+              <p className="text-sm text-slate-700">
+                Audit trail of all recorded stamp events for this product.
+              </p>
+            </div>
+          </div>
+
+          {/* Table */}
+          <div className="overflow-x-auto rounded-3xl border border-slate-200 bg-slate-50">
+            {isLoading ? (
+              <div className="flex items-center justify-center px-6 py-16">
+                <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-primary" />
+              </div>
+            ) : fetchError ? (
+              <div className="px-6 py-6 text-sm text-red-700">{fetchError}</div>
+            ) : (
+              <table className="min-w-full text-left text-sm text-slate-700">
+                <thead className="bg-slate-100 text-xs uppercase tracking-[0.22em] text-slate-500">
+                  <tr>
+                    <th className="px-4 py-3">#</th>
+                    <th className="px-4 py-3">Stamp</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-200">
+                  {pageItems.length > 0 ? (
+                    pageItems.map((entry, idx) => (
+                      <tr key={entry.id} className="bg-white">
+                        <td className="px-4 py-4 text-slate-400 font-mono text-xs w-12">
+                          {startIndex + idx + 1}
+                        </td>
+                        <td className="px-4 py-4 font-mono text-slate-800 text-xs tracking-wide">
+                          {entry.stamp}
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td
+                        colSpan={2}
+                        className="px-4 py-6 text-center text-sm text-slate-500"
+                      >
+                        No stamp history found for this product.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          {/* Pagination */}
+          {!isLoading && !fetchError && history && history.length > PAGE_SIZE && (
+            <div className="mt-4 flex items-center justify-between">
+              <p className="text-xs font-medium text-slate-500">
+                Showing {startIndex + 1}–{Math.min(startIndex + PAGE_SIZE, history.length)} of{' '}
+                {history.length} entries
+              </p>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage === 1}
+                  className="p-1.5 rounded text-slate-400 hover:text-slate-700 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                  aria-label="Previous page"
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                </button>
+
+                {Array.from({ length: totalPages }, (_, i) => i + 1)
+                  .filter(
+                    (page) =>
+                      page === 1 ||
+                      page === totalPages ||
+                      (page >= currentPage - 1 && page <= currentPage + 1)
+                  )
+                  .map((page, index, array) => (
+                    <React.Fragment key={page}>
+                      {index > 0 && array[index - 1] !== page - 1 && (
+                        <span className="px-1 text-slate-400 text-xs">…</span>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => setCurrentPage(page)}
+                        className={`w-7 h-7 flex items-center justify-center rounded text-xs font-medium transition-colors ${
+                          currentPage === page
+                            ? 'bg-[#1a56db] text-white'
+                            : 'text-slate-600 hover:bg-slate-100'
+                        }`}
+                      >
+                        {page}
+                      </button>
+                    </React.Fragment>
+                  ))}
+
+                <button
+                  type="button"
+                  onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={currentPage === totalPages}
+                  className="p-1.5 rounded text-slate-400 hover:text-slate-700 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                  aria-label="Next page"
+                >
+                  <ChevronRight className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+};

--- a/src/pages/ProductListPage.tsx
+++ b/src/pages/ProductListPage.tsx
@@ -6,6 +6,7 @@ import { AddProductModal } from '../components/products/AddProductModal';
 import { EditProductModal } from '../components/products/EditProductModal';
 import { SoftDeleteConfirmDialog } from '../components/products/SoftDeleteConfirmDialog';
 import { PriceHistoryPanel } from '../components/products/PriceHistoryPanel';
+import { StampHistoryPanel } from '../components/products/StampHistoryPanel';
 import { Search, ChevronDown, ChevronUp, Edit2, Trash2, ChevronLeft, ChevronRight, Info, History, Shield, Plus, Filter, ArrowUpDown } from 'lucide-react';
 import { SkeletonTable } from '../components/shared/SkeletonTable';
 import { EmptyState } from '../components/shared/EmptyState';
@@ -429,6 +430,13 @@ export const ProductListPage: React.FC = () => {
                     onPriceSaved={(unitPrice) => handlePriceSaved(product.prodcode, unitPrice)}
                     colSpan={hasRight('STAMP') ? 6 : 5}
                   />
+                  {hasRight('STAMP') && (
+                    <StampHistoryPanel
+                      productId={product.prodcode}
+                      isOpen={!!expandedRows[product.prodcode]}
+                      colSpan={hasRight('STAMP') ? 6 : 5}
+                    />
+                  )}
                   </React.Fragment>
                 ))
               )}

--- a/src/pages/ProductListPage.tsx
+++ b/src/pages/ProductListPage.tsx
@@ -544,8 +544,12 @@ export const ProductListPage: React.FC = () => {
           isOpen={isEditModalOpen}
           onClose={() => setIsEditModalOpen(false)}
           product={selectedProductForEdit}
-          onProductSaved={(updatedProduct) => {
+          currentPrice={priceMap[selectedProductForEdit.prodcode]}
+          onProductSaved={(updatedProduct, newPrice) => {
             setProducts(products.map(p => p.prodcode === updatedProduct.prodcode ? updatedProduct : p));
+            if (newPrice !== undefined) {
+              setPriceMap(prev => ({ ...prev, [updatedProduct.prodcode]: newPrice }));
+            }
           }}
         />
       )}


### PR DESCRIPTION
Product dropdown and database only retain the most recent stamp instead of full history.

**Steps to reproduce:** 
1. Navigate to the Products page. 
2. 2. Expand the row dropdown for a product that has been updated or modified multiple times. 
3. 3. Review the stamp information displayed.

The database should now maintain an audit trail of all stamps, and the UI dropdown should display the complete history/log of every stamp created for that specific product over time.