### PR TITLE
docs: Add user provisioning trigger SQL (retroactive Sprint 1)

### DIFF
--- a/sql/provision-user-trigger.sql
+++ b/sql/provision-user-trigger.sql
@@ -1,0 +1,32 @@
+-- Trigger function to map newly authenticated users to the public.users table
+CREATE OR REPLACE FUNCTION public.provision_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Insert the authenticated user record into the public schema
+  INSERT INTO public.users (
+    userid, 
+    email, 
+    username, 
+    user_type, 
+    record_status, 
+    stamp
+  )
+  VALUES (
+    new.id, 
+    new.email, 
+    -- Extract the user's full name from OAuth metadata, defaulting to the email prefix if unavailable
+    COALESCE(new.raw_user_meta_data->>'full_name', split_part(new.email, '@', 1)), 
+    'USER', 
+    'INACTIVE', 
+    NOW()
+  );
+  
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Trigger to execute after every insert on the Supabase auth.users table
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.provision_new_user();


### PR DESCRIPTION
### Overview
This PR adds the SQL documentation for the `provision_new_user()` database trigger to our codebase. 

**Note:** This feature was already fully implemented, tested, and deployed during Sprint 1. I forgot to document it at the time, so this PR is strictly adding the SQL file now for proper project documentation and version control.

### What this SQL does:
* Creates a trigger that automatically listens for new Google sign-ups.
* Copies the new user from Supabase's private `auth.users` table into our `public.users` table.
* Automatically sets their initial role to `USER` and their status to `INACTIVE`.